### PR TITLE
CLI id needs to be passed into SSO initializer

### DIFF
--- a/lib/heroku/kensa/client.rb
+++ b/lib/heroku/kensa/client.rb
@@ -78,7 +78,7 @@ module Heroku
       def sso
         id = @args.shift || abort("! no id specified; see usage")
         data = decoded_manifest
-        sso = Sso.new(data.merge(@options)).start
+        sso = Sso.new(data.merge(@options).merge(:id => id)).start
         puts sso.message
         Launchy.open sso.sso_url
       end


### PR DESCRIPTION
running `kensa sso id` was leaving actual id off of query params on proxy post
