### PR TITLE
merge the id with the rest of the options sent to Sso

### DIFF
--- a/lib/heroku/kensa/client.rb
+++ b/lib/heroku/kensa/client.rb
@@ -78,7 +78,7 @@ module Heroku
       def sso
         id = @args.shift || abort("! no id specified; see usage")
         data = decoded_manifest
-        sso = Sso.new(data.merge(@options)).start
+        sso = Sso.new(data.merge(@options).merge(:id => id)).start
         puts sso.message
         Launchy.open sso.sso_url
       end


### PR DESCRIPTION
The problem that this patch fixes is that if you type `kensa sso 123` the ID won't be added to the post data sent to the server

I guess there should be some kind of test for this part but i couldn't find any nor a good point to add new ones.. =/
