### PR TITLE
AllCheck only runs PlanCheck if --plan specified

### DIFF
--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -490,8 +490,10 @@ module Heroku
           screen.message "End of #{args.first}\n"
         end
 
-        data[:plan] ||= 'foo'
-        run PlanChangeCheck, data
+        # Only run the plan change if a plan is specified.
+        if data[:plan]
+          run PlanChangeCheck, data
+        end
         run DeprovisionCheck, data
       end
 


### PR DESCRIPTION
Rather than setting data[:plan] to a bogus value when a plan hasn't been specified, omit the PlanCheck entirely.  This is one approach to solving https://github.com/heroku/kensa/issues/32.
