### PR TITLE
Swap ordering of message output and abort

### DIFF
--- a/bin/kensa
+++ b/bin/kensa
@@ -16,8 +16,8 @@ begin
   ARGV.clear
   Client.new(args).run!
 rescue Client::CommandInvalid => e
-  abort File.read(__FILE__).split('__END__').last
   puts e.message unless e.message.empty?
+  abort File.read(__FILE__).split('__END__').last
 end
 
 __END__


### PR DESCRIPTION
Swap the ordering here, otherwise you never get the output of `raise CommandInvalid`

Refs #41
