### PR TITLE
Fix sso check boomerang

### DIFF
--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -454,7 +454,10 @@ module Heroku
         end
 
         check "displays the heroku layout" do
-          error("could not find Heroku layout") if page_logged_in.search('div#heroku-header').empty?
+            if page_logged_in.search('div#heroku-header').empty? &&
+              page_logged_in.search('script[src*=boomerang]').empty?
+              error("could not find Heroku layout")
+            end
           true
         end
       end


### PR DESCRIPTION
As described in issue #46, using the new Heroku nav header ([boomerang](https://github.com/heroku/boomerang)) causes a few kensa checks to fail.

This changeset makes kensa check for the JS which loads the new header, in addition to the old header HTML.
