### PR TITLE
make kensa send the 'app' parameter during sso

### DIFF
--- a/lib/heroku/kensa/sso.rb
+++ b/lib/heroku/kensa/sso.rb
@@ -72,7 +72,8 @@ module Heroku
         { 'token'     => @token,  
           'timestamp' => @timestamp.to_s,
           'nav-data'  => sample_nav_data,
-          'email'     => 'username@example.com' 
+          'email'     => 'username@example.com',
+          'app'       => 'myapp'
         }.tap do |params|
           params.merge!('id' => @id) if self.POST?
         end

--- a/test/sso_test.rb
+++ b/test/sso_test.rb
@@ -22,6 +22,7 @@ class SsoTest < Test::Unit::TestCase
       assert_equal 'b6010f6fbb850887a396c2bc0ab23974003008f6', data['token'].first
       assert_equal '1262304000', data['timestamp'].first
       assert_equal 'username@example.com', data['email'].first
+      assert_equal 'myapp', data['app'].first
     end
 
     context 'sso' do


### PR DESCRIPTION
The documentation at https://addons.heroku.com/provider/resources/technical/how/sso/4 says that the sso request will include an 'app' parameter, but kensa doesn't seem to include that parameter when running `kensa sso <some-id>`
