### PR TITLE
Add a --callback option

### DIFF
--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -333,14 +333,14 @@ module Heroku
             server = TCPServer.open(7779)
             client = server.accept
             body = OkJson.encode(
-              id: "999",
-              name: "kensa-test-app",
-              config: data[:provision_response]["config"],
-              callback_url: "http://localhost:7779/vendor/apps/999",
-              owner_email: "kensa-test-app@example.com",
-              region: "amazon-web-services::us-east-1",
-              logplex_token: "example",
-              domains: ["example.com"]
+              :id => "999",
+              :name => "kensa-test-app",
+              :config => data[:provision_response]["config"],
+              :callback_url => "http://localhost:7779/vendor/apps/999",
+              :owner_email => "kensa-test-app@example.com",
+              :region => "amazon-web-services::us-east-1",
+              :logplex_token => "example",
+              :domains => ["example.com"]
             )
             puts body
             client.write(%(HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: #{body.size}\r\n\r\n#{body}))

--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -327,6 +327,26 @@ module Heroku
         data[:provision_response] = response
 
         run ProvisionResponseCheck, data
+
+        if data[:callback]
+          check "callback called" do
+            server = TCPServer.open(7779)
+            client = server.accept
+            body = OkJson.encode(
+              id: "999",
+              name: "kensa-test-app",
+              config: data[:provision_response]["config"],
+              callback_url: "http://localhost:7779/vendor/apps/999",
+              owner_email: "kensa-test-app@example.com",
+              region: "amazon-web-services::us-east-1",
+              logplex_token: "example",
+              domains: ["example.com"]
+            )
+            puts body
+            client.write(%(HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: #{body.size}\r\n\r\n#{body}))
+            true
+          end
+        end
       end
 
     ensure

--- a/lib/heroku/kensa/client.rb
+++ b/lib/heroku/kensa/client.rb
@@ -305,6 +305,7 @@ module Heroku
               o.on("-v", "--version")   { options[:command] = "version" }
               o.on("-s sso", "--sso")   { |method| options[:method] = method }
               o.on("--foreman")         { options[:foreman] = true }
+              o.on("--callback")        { options[:callback] = true }
               o.on("-t name", "--template") do |template|
                 options[:template] = template
               end


### PR DESCRIPTION
Addon providers may need to access the data from the callback_url as part
of the initial setup, so it's useful if kensa can stub that out too.
