### PR TITLE
Don't die simply because config var is missing from provisioning response

### DIFF
--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -2,6 +2,7 @@ require 'mechanize'
 require 'socket'
 require 'timeout'
 require 'uri'
+require 'term/ansicolor'
 
 module Heroku
   module Kensa
@@ -164,6 +165,7 @@ module Heroku
 
 
     class ProvisionResponseCheck < Check
+      include Term::ANSIColor
 
       def call!
         response = data[:provision_response]
@@ -192,7 +194,7 @@ module Heroku
             difference = data['api']['config_vars'] - response['config'].keys 
             unless difference.empty?
               verb = (difference.size == 1) ? "is" : "are"
-              error "#{difference.join(', ')} #{verb} missing from the manifest"
+              print "\n\t", yellow( "#{difference.join(', ')} #{verb} missing from the manifest")
             end
             true
           end

--- a/test/provision_response_check_test.rb
+++ b/test/provision_response_check_test.rb
@@ -67,11 +67,6 @@ class ProvisionResponseCheckTest < Test::Unit::TestCase
       assert_invalid
     end
 
-    test "asserts all vars in manifest are in response" do
-      @response["config"].delete('MYADDON_CONFIG')
-      assert_invalid
-    end
-
     test "is valid otherwise" do
       @response["config"]["MYADDON_URL"] = "http://localhost/abc" 
       assert_valid


### PR DESCRIPTION
PR for issue #62

Instead of throwing an error when a config var is missing from the initial provisioning response (because reasons in #62), just print a nice yellow warning with the missing config var's name.

Deleted the related test.

Happy to discuss in depth if we feel the need.
