### PR TITLE
Send a region for provision request checks

### DIFF
--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -282,6 +282,7 @@ module Heroku
           :plan => data[:plan] || 'test',
           :callback_url => callback, 
           :logplex_token => nil,
+          :region => "amazon-web-services::us-east-1",
           :options => data[:options] || {}
         }
 


### PR DESCRIPTION
It just sends the US East region for now (and does not accept a configurable value), but this changeset begins to address https://github.com/heroku/kensa/issues/68 (and satisfies my service's requirement that a region be sent with provision requests)
