### PR TITLE
Remove duplicate development dependency on "pry"

### DIFF
--- a/kensa.gemspec
+++ b/kensa.gemspec
@@ -39,6 +39,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<timecop>, "~> 0.6.1")
   s.add_development_dependency(%q<pry>)
   s.add_development_dependency(%q<test-unit>)
-  s.add_development_dependency(%q<pry>)
 end
 


### PR DESCRIPTION
Remove duplicate development dependency on "pry" which cause gemspec validation issue