### PR TITLE
Remove deprecated logplex_token

### DIFF
--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -281,7 +281,6 @@ module Heroku
           :heroku_id => heroku_id,
           :plan => data[:plan] || 'test',
           :callback_url => callback,
-          :logplex_token => nil,
           :region => "amazon-web-services::us-east-1",
           :options => data[:options] || {}
         }

--- a/test/resources/server.rb
+++ b/test/resources/server.rb
@@ -59,7 +59,7 @@ post '/heroku/resources' do
 end
 
 post '/working/heroku/resources' do
-  json_must_include(%w{heroku_id plan callback_url logplex_token options})
+  json_must_include(%w{heroku_id plan callback_url options})
   heroku_only!
   { :id => 123 }.to_json
 end


### PR DESCRIPTION
attn @heroku/add-ons 

This field has been deprecated for about 9 months and was officially supposed to be sunset last September. We do currently still send it, but it's no longer officially part of the interface nor should it be used, so I'm removing it from the `kensa` tests.

`log_input` should be add to the manifest `requires` and the `log_input_url` field should be used instead.