### PR TITLE
Update local manifest from server after push

### DIFF
--- a/lib/heroku/kensa/client.rb
+++ b/lib/heroku/kensa/client.rb
@@ -90,9 +90,13 @@ module Heroku
         host     = heroku_host
         data     = decoded_manifest
         resource = RestClient::Resource.new(host, user, password)
-        resource['provider/addons'].post(resolve_manifest, headers)
+        manifest = resource['provider/addons'].post(resolve_manifest, headers)
+
         puts "-----> Manifest for \"#{data['id']}\" was pushed successfully"
         puts "       Continue at #{(heroku_host)}/provider/addons/#{data['id']}"
+
+        # Update local manifest with response from addons.heroku.com
+        File.open(filename, 'w') { |f| f.puts manifest } unless manifest.strip.empty?
       rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
         abort("FAILED: #{e.response}")
       rescue RestClient::Unauthorized


### PR DESCRIPTION
This lets Heroku return a normalised manifest on response to a new manifest version. Initially, this will be used to amend the `$revising` key which we will use to make sure all manifest pushes are based on the latest revision, which gives Heroku the opportunity to revise and normalise manifest formats.

attn @heroku/add-ons.

https://github.com/heroku/addons.heroku.com/pull/1060 to be merged and deployed after this is merged and released.