### PR TITLE
Update client.rb

### DIFF
--- a/lib/heroku/kensa/client.rb
+++ b/lib/heroku/kensa/client.rb
@@ -28,7 +28,7 @@ module Heroku
         manifest.write
         screen.message "Initialized new addon manifest in #{filename}\n"
         if @options[:foreman]
-          screen.message "Initialized new .env file for foreman\n"
+          screen.message "Initialized new .env file\n"
         end
       end
 


### PR DESCRIPTION
Removed reference to foreman from screen message because Heroku Local has replaced Foreman in the Heroku Toolbelt   (https://devcenter.heroku.com/changelog-items/692). The .env file will be used by either foreman or forego but I don't think the message needs to mention them.