### PR TITLE
Region agnosticism

### DIFF
--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -103,7 +103,8 @@ module Heroku
             data["api"]["regions"].is_a?(Array)
         end
         check "contains at least the US region" do
-          data["api"]["regions"].include? "us"
+          data["api"]["regions"].include?("us") ||
+            data["api"]["regions"].include?("*")
         end
         check "contains only valid region names" do
           data["api"]["regions"].all? { |reg| Manifest::REGIONS.include? reg }

--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -99,8 +99,8 @@ module Heroku
           data["api"].is_a?(Hash)
         end
         check "has a list of regions" do
-          data["api"].has_key?("regions")
-          data["api"]["regions"].is_a?(Array)
+          data["api"].has_key?("regions") &&
+            data["api"]["regions"].is_a?(Array)
         end
         check "contains at least the US region" do
           data["api"]["regions"].include? "us"

--- a/lib/heroku/kensa/manifest.rb
+++ b/lib/heroku/kensa/manifest.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 module Heroku
   module Kensa
     class Manifest
-      REGIONS = %w(us eu)
+      REGIONS = %w(us eu *)
 
       def initialize(options = {})
         @method   = options.fetch(:method, 'post').to_sym

--- a/test/manifest_check_test.rb
+++ b/test/manifest_check_test.rb
@@ -50,6 +50,11 @@ class ManifestCheckTest < Test::Unit::TestCase
         assert_invalid
       end
 
+      test "api allows just wildcard region name" do
+        @data["api"]["regions"] = ["*"]
+        assert_valid
+      end
+
       test "api has a password" do
         @data["api"].delete("password")
         assert_invalid


### PR DESCRIPTION
Related work on backend: heroku/addons.heroku.com#1146.

This allows `kensa` to be aware of the "wildcard" region `*` which denotes region agnosticism. This *usually* means that your add-on is not affected by latency (but other concerns such as throughput might be also be a consideration) and does not need explicit work to be functional in arbitrary regions. This alleviates some annoyance with providers having to manually specify regions when it is not relevant to them.

This can be merged independently of the backend work but it might be prudent to wait until the above-referenced PR is merged and deployed so that any observant providers don't attempt to declare region agnosticism early

cc @heroku/add-ons 