### PR TITLE
Do not verify SSL certs when hitting test URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ how to build your Heroku add-on:
 
 ## Meta #######################################################################
 
-Maintained by the Heroku Add-ons Team (and you!).
+Maintained by the Heroku Ecosystem Team (and you!).
 
 Released under the MIT license. <https://github.com/heroku/kensa>

--- a/lib/heroku/kensa/check.rb
+++ b/lib/heroku/kensa/check.rb
@@ -299,7 +299,7 @@ module Heroku
     end
 
     class DuplicateProvisionCheck < ApiCheck
-      include HTTP
+      include HTTPForChecks
 
       READLEN = 1024 * 10
 
@@ -333,7 +333,7 @@ module Heroku
     end
 
     class ProvisionCheck < ApiCheck
-      include HTTP
+      include HTTPForChecks
 
       READLEN = 1024 * 10
 
@@ -420,7 +420,7 @@ module Heroku
 
 
     class DeprovisionCheck < ApiCheck
-      include HTTP
+      include HTTPForChecks
 
       def call!
         id = data[:id]
@@ -453,7 +453,7 @@ module Heroku
 
 
     class PlanChangeCheck < ApiCheck
-      include HTTP
+      include HTTPForChecks
 
       def call!
         id = data[:id]
@@ -488,7 +488,7 @@ module Heroku
 
 
     class SsoCheck < ApiCheck
-      include HTTP
+      include HTTPForChecks
 
       def agent
         @agent ||= Mechanize.new

--- a/lib/heroku/kensa/http.rb
+++ b/lib/heroku/kensa/http.rb
@@ -36,7 +36,7 @@ module Heroku
           end
 
           user, pass = credentials
-          body = RestClient::Resource.new(url, user, pass, verify_ssl: false)[path].send(
+          body = RestClient::Resource.new(url, user: user, password: pass, verify_ssl: false)[path].send(
             meth,
             *args
           ).to_s

--- a/lib/heroku/kensa/http.rb
+++ b/lib/heroku/kensa/http.rb
@@ -2,7 +2,7 @@ require 'restclient'
 
 module Heroku
   module Kensa
-    module HTTP
+    module HTTPForChecks
 
       def get(path, params={})
         path = "#{path}?" + params.map { |k, v| "#{k}=#{v}" }.join("&") unless params.empty?

--- a/lib/heroku/kensa/http.rb
+++ b/lib/heroku/kensa/http.rb
@@ -36,7 +36,7 @@ module Heroku
           end
 
           user, pass = credentials
-          body = RestClient::Resource.new(url, user, pass)[path].send(
+          body = RestClient::Resource.new(url, user, pass, verify_ssl: false)[path].send(
             meth,
             *args
           ).to_s


### PR DESCRIPTION
Fixes #102 

We are using RestClient to hit the test urls that providers set in their manifests. With a recent upgrade, RestClient will now error if the url is https but the cert is invalid. Many of our providers are using self-signed certs for their local dev servers, which means that all checks error out for them.

