### PR TITLE
Bump Kensa version to 3.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kensa (3.0.0)
+    kensa (3.0.1)
       colored (~> 1.2)
       launchy (~> 2.2.0)
       mechanize (~> 2.6.0)

--- a/lib/heroku/kensa/version.rb
+++ b/lib/heroku/kensa/version.rb
@@ -1,5 +1,5 @@
 module Heroku
   module Kensa
-    VERSION = '3.0.0'
+    VERSION = '3.0.1'
   end
 end


### PR DESCRIPTION
This will release the changes to allow test URLs to have self-signed certs