### PR TITLE
Bump rest-client to > 2.0

### DIFF
--- a/kensa.gemspec
+++ b/kensa.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<launchy>, "~> 2.2.0")
   s.add_runtime_dependency(%q<mechanize>, "~> 2.7.5")
   s.add_runtime_dependency(%q<netrc>, "~> 0.10.3")
-  s.add_runtime_dependency(%q<rest-client>, "~> 1.8")
+  s.add_runtime_dependency(%q<rest-client>, "~> 2.0")
   s.add_runtime_dependency(%q<colored>, "~> 1.2")
 
   s.add_development_dependency(%q<artifice>, "~> 0.6")


### PR DESCRIPTION
Running kensa with Ruby 2.4.X caused this:

```
Testing POST /Contrast/api/ng/heroku/resources
  Check response/Users/garymoore/.rvm/gems/ruby-2.4.2/gems/rest-client-1.8.0/lib/restclient/request.rb:163:in `fetch': key not found: :ciphers (KeyError)
	from /Users/garymoore/.rvm/gems/ruby-2.4.2/gems/rest-client-1.8.0/lib/restclient/request.rb:163:in `initialize'
```

The root cause is a problem in rest-client with Ruby 2.4. See: https://github.com/rest-client/rest-client/issues/612

This PR upgrades rest-client to 2.0. I've tested this locally with Ruby 2.4.2 and it works as expected.

(Incidentally, I couldn't get the test suite to run locally on master using `rake test`. Let me know if there's another way.)